### PR TITLE
[#135] Change level type to xsd:nonNegativeInteger

### DIFF
--- a/iati-activities-schema.xsd
+++ b/iati-activities-schema.xsd
@@ -918,7 +918,7 @@
                 </xsd:documentation>
               </xsd:annotation>
             </xsd:attribute>
-            <xsd:attribute name="level" type="xsd:positiveInteger" use="optional">
+            <xsd:attribute name="level" type="xsd:nonNegativeInteger" use="optional">
               <xsd:annotation>
                 <xsd:documentation xml:lang="en">
                    An integer indicating the hierarchical level being 

--- a/tests/activity-tests/should-pass/15-location.xml
+++ b/tests/activity-tests/should-pass/15-location.xml
@@ -8,7 +8,7 @@
       <location-type code="city"/>
       <name xml:lang="en">Kandahar</name>
       <description>West end of Kandahar-Kabul highway</description>
-      <administrative country="AF" adm1="KAN">Kandahar Province, Afghanistan</administrative>
+      <administrative country="AF" adm1="KAN" level="0">Kandahar Province, Afghanistan</administrative>
       <coordinates latitude="31.616944" longitude="65.716944" precision="city"/>
       <gazetteer-entry gazetteer-ref="[ref]">[identifier in gazetteer]</gazetteer-entry>
     </location>


### PR DESCRIPTION
And add appropriate test

This ensures that level="0" is valid https://github.com/IATI/IATI-Schemas/issues/135
