### PR TITLE
[#177] Removes the confusing date format guidance

### DIFF
--- a/iati-activities-schema.xsd
+++ b/iati-activities-schema.xsd
@@ -2296,8 +2296,7 @@
         <xsd:annotation>
           <xsd:documentation xml:lang="en">
             The exact date when the information was collected or
-            extracted from donors' aid management systems. (yyyy-mm-dd
-            plus [optional] timezone)
+            extracted from donors' aid management systems.
           </xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>


### PR DESCRIPTION
The extraction-date attribute  definition only needs to know that
it is of type xsd:date, so poor definition has been removed.
