### PR TITLE
support multiple actuals / targets

### DIFF
--- a/iati-activities-schema.xsd
+++ b/iati-activities-schema.xsd
@@ -1965,7 +1965,7 @@
                         <xsd:anyAttribute processContents="lax" namespace="##other"/>
                       </xsd:complexType>
                     </xsd:element>
-                    <xsd:element name="target" minOccurs="0" maxOccurs="1">
+                    <xsd:element name="target" minOccurs="0" maxOccurs="unbounded">
                       <xsd:annotation>
                         <xsd:documentation xml:lang="en">
                           The target milestone for this period
@@ -2035,7 +2035,7 @@
                         </xsd:attribute>
                       </xsd:complexType>
                     </xsd:element>
-                    <xsd:element name="actual" minOccurs="0" maxOccurs="1">
+                    <xsd:element name="actual" minOccurs="0" maxOccurs="unbounded">
                       <xsd:annotation>
                         <xsd:documentation xml:lang="en">
                           A record of the achieved result for this period.


### PR DESCRIPTION
Issue #294

Allows multiple actual / target amounts to be reported for a given indicator and period. This supports multiple amounts to be reported when you are varying by dimension and/or multiple locations