### PR TITLE
Decimal percentage boundary check

### DIFF
--- a/iati-activities-schema.xsd
+++ b/iati-activities-schema.xsd
@@ -357,7 +357,7 @@
           </xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
-      <xsd:attribute name="percentage" use="optional" type="xsd:decimal">
+      <xsd:attribute name="percentage" use="optional" type="decimalPercentage">
         <xsd:annotation>
           <xsd:documentation xml:lang="en">
             The percentage of total commitments or total activity
@@ -425,7 +425,7 @@
           </xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
-      <xsd:attribute name="percentage" use="optional" type="xsd:decimal">
+      <xsd:attribute name="percentage" use="optional" type="decimalPercentage">
         <xsd:annotation>
           <xsd:documentation xml:lang="en">
             The percentage of total commitments or total activity
@@ -656,7 +656,7 @@
           </xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
-      <xsd:attribute name="percentage" use="optional" type="xsd:decimal">
+      <xsd:attribute name="percentage" use="optional" type="decimalPercentage">
         <xsd:annotation>
           <xsd:documentation xml:lang="en">
             The percentage of total commitments or total activity budget to this item.
@@ -981,7 +981,7 @@
       <xsd:sequence>
         <xsd:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
       </xsd:sequence>
-      <xsd:attribute name="percentage" use="required" type="xsd:decimal">
+      <xsd:attribute name="percentage" use="required" type="decimalPercentage">
         <xsd:annotation>
           <xsd:documentation xml:lang="en">
             The percentage of the total commitment allocated to or
@@ -1738,7 +1738,7 @@
                 </xsd:documentation>
               </xsd:annotation>
             </xsd:attribute>
-            <xsd:attribute name="percentage" use="optional" type="xsd:decimal">
+            <xsd:attribute name="percentage" use="optional" type="decimalPercentage">
               <xsd:annotation>
                 <xsd:documentation xml:lang="en">
                   When multiple budget-item elements are declared

--- a/iati-common.xsd
+++ b/iati-common.xsd
@@ -180,4 +180,11 @@
     <xsd:anyAttribute processContents="lax" namespace="##other"/>
   </xsd:complexType>
 
+  <xsd:simpleType name="decimalPercentage">
+    <xsd:restriction base="xsd:decimal">
+       <xsd:minInclusive value="0"/>
+       <xsd:maxInclusive value="100"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
 </xsd:schema>

--- a/tests/activity-tests/should-fail/27-decimal-percentage-out-of-bounds.xml
+++ b/tests/activity-tests/should-fail/27-decimal-percentage-out-of-bounds.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+
+<iati-activities version="xx">
+  <iati-activity> <!-- at least 1 -->
+    <iati-identifier></iati-identifier>  <!-- 1 and only 1-->
+    <reporting-org type="xx" ref="xx"><narrative>Organisation name</narrative></reporting-org> <!-- 1 and only 1-->
+    <title> <!-- 1 and only 1-->
+      <narrative>Xxxxxxx</narrative> <!-- At least 1-->
+    </title>
+    <description>
+      <narrative>Xxxxxxx</narrative> <!-- At least 1-->
+    </description>
+    <participating-org role="xx"></participating-org> <!-- At least 1-->
+    <!--<other-identifier></other-identifier>-->
+    <activity-status code="xx"/> <!-- 1 and only 1-->
+    <activity-date type="xx" iso-date="2013-11-27"/><!-- At least 1 --> <!--Narative allowed-->
+    
+    <!-- use a decimal for percentage -->
+    <recipient-country code="XX" percentage="101.5" />
+    <recipient-region vocabulary="AA" code="XX" percentage="11.1" />
+    <location />
+    <sector code="XX" percentage="70.9999" />
+  </iati-activity>
+</iati-activities>

--- a/tests/activity-tests/should-pass/48-decimal-percentage-boundaries.xml
+++ b/tests/activity-tests/should-pass/48-decimal-percentage-boundaries.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<iati-activities version="xx">
+  <iati-activity> <!-- at least 1 -->
+    <iati-identifier></iati-identifier>  <!-- 1 and only 1-->
+    <reporting-org type="xx" ref="xx"><narrative>Organisation name</narrative></reporting-org> <!-- 1 and only 1-->
+    <title> <!-- 1 and only 1-->
+      <narrative>Xxxxxxx</narrative> <!-- At least 1-->
+    </title>
+    <description>
+      <narrative>Xxxxxxx</narrative> <!-- At least 1-->
+    </description>
+    <participating-org role="xx"></participating-org> <!-- At least 1-->
+    <!--<other-identifier></other-identifier>-->
+    <activity-status code="xx"/> <!-- 1 and only 1-->
+    <activity-date type="xx" iso-date="2013-11-27"/><!-- At least 1 --> <!--Narative allowed-->
+    
+    <!-- use a decimal for percentage -->
+    <recipient-country code="XX" percentage="100" />
+    <recipient-region vocabulary="AA" code="XX" percentage="0" />
+    <location />
+    <sector code="XX" percentage="70.9999" />
+  </iati-activity>
+</iati-activities>


### PR DESCRIPTION
This checks if the all percentages are within the set boundaries (0 - 100). 

2 Tests added, 26-decimal-percentage.xml was already there to check valid decimal percentages. Added 48-decimal-percentage-boundaries.xml to make sure I didn't accidentally make percentage="100" invalid. Added failed state 27-decimal-percentage-out-of-bounds.xml to invalidate percentages over a 100. 

This is probably backward compatible for version 2.01 and 1.0x.