### PR TITLE
Update definition of transaction sector vocabulary-uri attribute

### DIFF
--- a/iati-activities-schema.xsd
+++ b/iati-activities-schema.xsd
@@ -1144,7 +1144,7 @@
             <xsd:attribute name="vocabulary-uri" type="xsd:anyURI" use="optional">
               <xsd:annotation>
                 <xsd:documentation xml:lang="en">
-                If the vocabulary is 99 or 98 (reporting organisation), the URI where this internal vocabulary is defined.
+                The URI where this vocabulary is defined. If the vocabulary is 99 or 98 (reporting organisation), the URI where this internal vocabulary is defined. While this is an optional field it is STRONGLY RECOMMENDED that all publishers use it to ensure that the meaning of their codes are fully understood by data users.
                 </xsd:documentation>
               </xsd:annotation>
             </xsd:attribute>


### PR DESCRIPTION
Amends definition of `iati-activity/transaction/sector/@vocabulary-uri` in accordance with #341 

Adds an additional definition change (identified [here](https://github.com/IATI/IATI-Schemas/pull/391#issuecomment-365568200)) to fully fix #341. This change is related to PRs #398 and #411 for issue #341.