### PR TITLE
bug fix - missing rule in 2.03 activity and org schemas

### DIFF
--- a/iati-activities-schema.xsd
+++ b/iati-activities-schema.xsd
@@ -168,7 +168,7 @@
       <xsd:attribute ref="xml:lang">
         <xsd:annotation>
           <xsd:documentation xml:lang="en">
-            A code specifying the default language of text in this activity. It is recommended that wherever possible only codes from ISO 639-1 are used.
+            A code specifying the default language of text in this activity. It is recommended that wherever possible only codes from ISO 639-1 are used. If this is not declared then the xml:lang attribute MUST be specified for each narrative element.
           </xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>

--- a/iati-organisations-schema.xsd
+++ b/iati-organisations-schema.xsd
@@ -96,7 +96,7 @@
       <xsd:attribute ref="xml:lang">
         <xsd:annotation>
           <xsd:documentation xml:lang="en">
-            A code specifying the default language of text in this organisation. It is recommended that wherever possible only codes from ISO 639-1 are used.
+            A code specifying the default language of text in this organisation. It is recommended that wherever possible only codes from ISO 639-1 are used. If this is not declared then the xml:lang attribute MUST be specified for each narrative element.
           </xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>


### PR DESCRIPTION
At 2.03 the wording for the default language xml:lang attribute was updated. Whist doing this, the rule that the default language must be specified, or all narrative elements must have a language set was missed out.

https://discuss.iatistandard.org/t/language-recommend-use-of-iso-639-1-included-2-03/842

This PR fixes this bug.