### PR TITLE
Update country and region rule - 2.03

### DIFF
--- a/iati-activities-schema.xsd
+++ b/iati-activities-schema.xsd
@@ -356,7 +356,7 @@
       <xsd:attribute name="percentage" use="optional" type="xsd:decimal">
         <xsd:annotation>
           <xsd:documentation xml:lang="en">
-            The percentage of total commitments or total activity budget to this item. Content must be a decimal number between 0 and 100 inclusive, with no percentage sign. Percentages for all reported countries and regions MUST add up to 100.
+            The percentage of total commitments or total activity budget to this item. Content must be a decimal number between 0 and 100 inclusive, with no percentage sign. Percentages for all reported countries and regions within a vocabulary MUST add up to 100.
           </xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
@@ -419,7 +419,7 @@
       <xsd:attribute name="percentage" use="optional" type="xsd:decimal">
         <xsd:annotation>
           <xsd:documentation xml:lang="en">
-            The percentage of total commitments or total activity budget to this item. Content must be a decimal number between 0 and 100 inclusive, with no percentage sign. Percentages for all reported countries and regions MUST add up to 100.
+            The percentage of total commitments or total activity budget to this item. Content must be a decimal number between 0 and 100 inclusive, with no percentage sign. Percentages for all reported countries and regions within a vocabulary MUST add up to 100.
           </xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>


### PR DESCRIPTION
The rules within the IATI Standard and the surrounding documentation are unclear and inconsistent whether or not publishers can map their activities to different region vocabularies. Or, if all reported regions + countries have to make up 100% of the activity.

We propose a bug fix to confirm that publishers can map their activities to multiple region vocabularies e.g. 100% to OECD DAC and 100% to UN Region list.

https://github.com/IATI/IATI-Extra-Documentation/issues/544
https://github.com/IATI/IATI-Extra-Documentation/pull/516

Needs to be posted and agreed on Discuss before merging.