### PR TITLE
Clarify budget not provided rule

### DIFF
--- a/iati-activities-schema.xsd
+++ b/iati-activities-schema.xsd
@@ -214,7 +214,7 @@
       <xsd:attribute name="budget-not-provided" type="xsd:string" use="optional">
         <xsd:annotation>
           <xsd:documentation xml:lang="en">
-            A code indicating the reason why this activity does not contain any iati-activity/budget elements. The value must exist in the BudgetNotProvided codelist.
+            A code indicating the reason why this activity does not contain any iati-activity/budget elements. The code MUST only be used when no budget elements are present.
           </xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>

--- a/iati-activities-schema.xsd
+++ b/iati-activities-schema.xsd
@@ -214,7 +214,7 @@
       <xsd:attribute name="budget-not-provided" type="xsd:string" use="optional">
         <xsd:annotation>
           <xsd:documentation xml:lang="en">
-            A code indicating the reason why this activity does not contain any iati-activity/budget elements. The code MUST only be used when no budget elements are present.
+            A code indicating the reason why this activity does not contain any iati-activity/budget elements. The attribute MUST only be used when no budget elements are present.
           </xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>


### PR DESCRIPTION
Bug fix to budget not provided as per: https://discuss.iatistandard.org/t/bug-fix-budget-not-provided-contains-a-rule/1612

Also removed the text 'must be in codelist' as this is repetition.