### PR TITLE
Adding document-link description in the organisation schema for v2.03

### DIFF
--- a/iati-organisations-schema.xsd
+++ b/iati-organisations-schema.xsd
@@ -770,6 +770,11 @@
   <xsd:complexType name="documentLinkWithReceipientCountry">
     <xsd:complexContent>
       <xsd:extension base="documentLinkBase">
+        <xsd:anotation>
+          <xsd:documentation xml:lang="en">
+            A link to an online, publicly accessible web page or document expanding on the result
+          </xsd:documentation>
+        </xsd:anotation>
         <xsd:sequence>
           <xsd:element name="recipient-country" minOccurs="0" maxOccurs="unbounded">
             <xsd:annotation>


### PR DESCRIPTION
Currently the description for `iati-organisations/iati-organisation/document-link/` for version 2.03 is incorrect, as it's pulling the definition from `iati-organisations/iati-organisation/document-link/recipient-country/`, this PR resolves that. 