### PR TITLE
`xsd:anotation` should be `xsd:annotation`

### DIFF
--- a/iati-organisations-schema.xsd
+++ b/iati-organisations-schema.xsd
@@ -744,11 +744,11 @@
   <xsd:complexType name="documentLinkWithReceipientCountry">
     <xsd:complexContent>
       <xsd:extension base="documentLinkBase">
-        <xsd:anotation>
+        <xsd:annotation>
           <xsd:documentation xml:lang="en">
             A link to an online, publicly accessible web page or document expanding on the result
           </xsd:documentation>
-        </xsd:anotation>
+        </xsd:annotation>
         <xsd:sequence>
           <xsd:element name="recipient-country" minOccurs="0" maxOccurs="unbounded">
             <xsd:annotation>


### PR DESCRIPTION
Fixes typo introduced in #438.