### PR TITLE
Migration to GitHub Actions for version 2.02

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,4 +26,6 @@ jobs:
         run: xmllint --schema http://www.w3.org/2001/XMLSchema.xsd --noout *.xsd
 
       - name: Run complete schema test suite
-        run: ./tests/run-tests.sh
+        run: |
+          - cd tests  
+          - ./run-tests.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,9 +5,9 @@ name: CI_Tests
 
 on:
   push:
-    branches: [version-2.02, version-2.01]
+    branches: [version-2.02]
   pull_request:
-    branches: [version-2.02, version-2.01]
+    branches: [version-2.02]
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,5 +27,5 @@ jobs:
 
       - name: Run complete schema test suite
         run: |
-          - cd tests  
-          - ./run-tests.sh
+          cd tests  
+          ./run-tests.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,29 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: CI_Tests
+
+on:
+  push:
+    branches: [version-2.02, version-2.01]
+  pull_request:
+    branches: [version-2.02, version-2.01]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.6"]
+
+    steps:
+      - name: Install xmllint
+        run: sudo apt-get install libxml2-utils
+
+      - uses: actions/checkout@v2
+
+      - name: xmllint the schema
+        run: xmllint --schema http://www.w3.org/2001/XMLSchema.xsd --noout *.xsd
+
+      - name: Run complete schema test suite
+        run: ./tests/run-tests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-before_install:
-    - sudo apt-get update -qq
-    - sudo apt-get install -qq libxml2-utils
-script:
-    - xmllint --schema http://www.w3.org/2001/XMLSchema.xsd --noout *.xsd
-    - cd tests
-    - ./run-tests.sh
-

--- a/README.rst
+++ b/README.rst
@@ -4,9 +4,6 @@ International Aid Transparency Initiative (IATI) XML Schemas
 .. image:: https://github.com/IATI/IATI-Schemas/workflows/CI_Tests/badge.svg
    :target: https://github.com/IATI/IATI-Schemas/actions
 
-.. image:: https://travis-ci.org/IATI/IATI-Schemas.svg?branch=version-2.02
-    :target: https://travis-ci.org/IATI/IATI-Schemas
-
 | IATI Support <support@iatistandard.org>
 | Release 2.02, 2015-12-07
 

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,9 @@
 International Aid Transparency Initiative (IATI) XML Schemas
 ============================================================
 
+.. image:: https://github.com/IATI/IATI-Schemas/workflows/CI_Tests/badge.svg
+   :target: https://github.com/IATI/IATI-Schemas/actions
+
 .. image:: https://travis-ci.org/IATI/IATI-Schemas.svg?branch=version-2.02
     :target: https://travis-ci.org/IATI/IATI-Schemas
 


### PR DESCRIPTION
## Summary
- TravisCI.org is read-only after 31 Dec 2020 so we're migrating to GitHub Actions to run the CI tests/linting.

## Notes
- This is different than the main.yml file for version-2.03 which includes pytest. 