### PR TITLE
tests: Lint using flake8

### DIFF
--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -21,7 +21,7 @@ class SchemaFactory(object):
 
             self.organisation_schema - v2.03 IATI Organisation schema.
         """
-        self.activity_schema  = etree.XMLSchema(etree.parse('iati-activities-schema.xsd'))
+        self.activity_schema = etree.XMLSchema(etree.parse('iati-activities-schema.xsd'))
 
         self.organisation_schema = etree.XMLSchema(etree.parse('iati-organisations-schema.xsd'))
 
@@ -85,13 +85,12 @@ def is_xml(xml_string):
 
 
 def is_iati_xml(xml_string, schema):
-    parser = etree.XMLParser(schema = schema)
+    parser = etree.XMLParser(schema=schema)
     try:
-        dataset = etree.fromstring(xml_string, parser)
+        etree.fromstring(xml_string, parser)
         return True
     except etree.XMLSyntaxError:
         return False
-
 
 
 @pytest.mark.parametrize('filepath', list_xml_files_recursively('tests/activity-tests/should-pass/') +  # Legacy activity test cases
@@ -144,9 +143,9 @@ def test_2_03_fail_files(schema_factory, filepath):
 
     assert is_xml(data_str)
 
-    parser = etree.XMLParser(schema = schema)
+    parser = etree.XMLParser(schema=schema)
     try:
-        dataset = etree.fromstring(data_str, parser)
+        etree.fromstring(data_str, parser)
     except etree.XMLSyntaxError as error_log:
         expected_error_text = failure_reason_mapping[failure_reason]
         if re.search(expected_error_text, str(error_log)) is None:


### PR DESCRIPTION
This is required due to tests in the IATI-Standard-SSOT repo:
https://github.com/IATI/IATI-Standard-SSOT/actions/runs/20164348502/job/57884033321
https://github.com/IATI/IATI-Standard-SSOT/blob/5f2c1e49ff263d18853cae33098dfad70749c938/.github/workflows/CI.yml#L42-L43